### PR TITLE
feat: add 'Run Action' functionality and system info variables

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -440,6 +440,34 @@ export function getActions() {
 			this.getCGProjects()
 		},
 	}
+	actions['runAction'] = {
+		name: 'Run Action (AppleScript)',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Action',
+				id: 'action',
+				default: '',
+				choices: (this.availableActions || []).map((action) => ({ id: action, label: action })),
+				tooltip: 'Select an available action to run',
+				required: true,
+			},
+			{
+				type: 'textinput',
+				label: 'Parameter (optional)',
+				id: 'parameter',
+				default: '',
+				tooltip: 'Optional parameter to pass to the action',
+				required: false,
+				useVariables: true,
+			},
+		],
+		callback: async (event) => {
+			const parameter = await this.parseVariablesInString(event.options.parameter)
+			const cmd = `actions/${event.options.action}/run?parameter=${encodeURIComponent(parameter)}`
+			await this.sendGetRequest(cmd)
+		},
+	}
 
 	return actions
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -5,6 +5,20 @@ export function updateVariableDefinitions() {
 	this.log('debug', 'Running updateVariableDefinitions')
 	const variables = []
 
+	// system info vars:
+	variables.push({
+		name: 'Application Version',
+		variableId: 'applicationVersion',
+	})
+	variables.push({
+		name: 'macOS Version',
+		variableId: 'macOSVersion',
+	})
+	variables.push({
+		name: 'Computer Name',
+		variableId: 'computerName',
+	})
+
 	// playback status vars:
 	variables.push({
 		name: 'Playback status',
@@ -72,6 +86,17 @@ export function updateVariableDefinitions() {
 
 	this.setVariableDefinitions(variables)
 	this.updatePlaylistVariables()
+}
+
+/**
+ * Update the values of system info variables.
+ */
+export function updateInfoVariables(info) {
+	let list = {}
+	list['applicationVersion'] = info.application_version || '-'
+	list['macOSVersion'] = info.mac_os_version || '-'
+	list['computerName'] = info.computer_name || '-'
+	this.setVariableValues(list)
 }
 
 /**


### PR DESCRIPTION
Summary
-Add support for /info endpoint to fetch system information and available actions
-Add variables for applicationVersion, macOSVersion, and computerName from /info endpoint
-Add "Run Action (AppleScript)" action with dropdown populated from available actions list
Changes Made
index.js:
-Added this.info and this.availableActions properties to store /info endpoint data
-Added getInfo() method to fetch system information
-Integrated /info call into connection success flow
-Added processing for /info response data
variables.js:
-Added updateInfoVariables() function to update system info variables
-Added three new variable definitions: applicationVersion, macOSVersion, computerName
actions.js:
-Added runAction action to execute OnTheAir Video AppleScript actions via API
-Dropdown automatically populated with available actions from /info endpoint
-Includes optional parameter field with variable support
-API call always includes ?parameter= query string as required by API
API Endpoints Used
-GET /info - Fetches system info and available actions list
-GET /actions/{name}/run?parameter={parameter} - Executes AppleScript actions